### PR TITLE
Use smart pointers for packet lifetimes

### DIFF
--- a/nic-sim-hw6/nic-sim-hw6/L2.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L2.cpp
@@ -2,6 +2,7 @@
 #include <cctype>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 
 using namespace common;
 
@@ -35,8 +36,7 @@ l2_packet::l2_packet(const std::string& s) {
         return;
     }
 
-    inner_ = new l3_packet(inner);
-    owns_inner_ = true;
+    inner_ = std::unique_ptr<l3_packet>(new l3_packet(inner));
     l3_string_ = inner;
     valid_parse_ = true;
 }
@@ -125,11 +125,4 @@ bool l2_packet::as_string(std::string &packet) {
     packet += s_mac + "|" + d_mac + "|" + out_l3_string_ + "|";
     packet += std::to_string(0);
     return true;
-}
-
-l2_packet::~l2_packet() {
-    if (owns_inner_) {
-        delete inner_;
-        inner_ = nullptr;
-    }
 }

--- a/nic-sim-hw6/nic-sim-hw6/L2.h
+++ b/nic-sim-hw6/nic-sim-hw6/L2.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 #include "common.hpp"
 #include "packets.hpp"
 #include "L3.h"
@@ -23,7 +24,7 @@ public:
 
     bool as_string(std::string &packet) override;
 
-    ~l2_packet() override;
+    ~l2_packet() override = default;
 
 private:
     static bool parse_mac(const std::string& s, uint8_t out[common::MAC_SIZE]);
@@ -35,8 +36,7 @@ private:
     std::string l3_string_;
     bool valid_parse_{false};
 
-    l3_packet* inner_{nullptr};
-    bool owns_inner_{false};
+    std::unique_ptr<l3_packet> inner_;
 
     std::string out_l3_string_;
     uint32_t out_checksum_{0};

--- a/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
@@ -119,16 +119,14 @@ void nic_sim::nic_flow(std::string packet_file) {
     std::string line;
     while (std::getline(in, line)) {
         if (line.empty()) continue;
-        generic_packet* pkt = packet_factory(line);
+        auto pkt = packet_factory(line);
         if (!pkt) continue;
 
         if (!pkt->validate_packet(open_ports, priv->ip, priv->mask_bits, priv->mac)) {
-            delete pkt;
             continue;
         }
         memory_dest dst;
         if (!pkt->proccess_packet(open_ports, priv->ip, priv->mask_bits, dst)) {
-            delete pkt;
             continue;
         }
         if (dst == common::RQ || dst == common::TQ) {
@@ -136,7 +134,6 @@ void nic_sim::nic_flow(std::string packet_file) {
             pkt->as_string(s);
             if (dst == common::RQ) RQ.push_back(s); else TQ.push_back(s);
         }
-        delete pkt;
     }
 }
 
@@ -193,12 +190,12 @@ static bool looks_like_l3_packet(const std::string& s) {
     return is_ip(first);
 }
 
-generic_packet* nic_sim::packet_factory(std::string &packet) {
+std::unique_ptr<generic_packet> nic_sim::packet_factory(std::string &packet) {
     if (looks_like_mac_packet(packet)) {
-        return new l2_packet(packet);
+        return std::unique_ptr<generic_packet>(new l2_packet(packet));
     } else if (looks_like_l3_packet(packet)) {
-        return new l3_packet(packet);
+        return std::unique_ptr<generic_packet>(new l3_packet(packet));
     } else {
-        return new l4_packet(packet);
+        return std::unique_ptr<generic_packet>(new l4_packet(packet));
     }
 }

--- a/nic-sim-hw6/nic-sim-hw6/NIC_sim.hpp
+++ b/nic-sim-hw6/nic-sim-hw6/NIC_sim.hpp
@@ -17,6 +17,7 @@
 #include "L2.h"
 #include "L3.h"
 #include "L4.h"
+#include <memory>
 
 class nic_sim {
     public:
@@ -77,7 +78,7 @@ class nic_sim {
      *
      * @return Pointer to a generic_packet object.
      */
-    generic_packet *packet_factory(std::string &packet);
+    std::unique_ptr<generic_packet> packet_factory(std::string &packet);
 
     /**
      * @param open_ports - Vector containing all open communications.


### PR DESCRIPTION
## Summary
- replace raw inner packet pointer in L2 with `std::unique_ptr`
- build packet objects with unique pointers to avoid manual deletes
- streamline NIC flow using RAII for packet memory

## Testing
- `make clean && make`
- `./nic_sim.exe ../../test_students/test0_param.in ../../test_students/test0_packets.in > /tmp/test0.out && diff -u ../../test_students/test0_res.out /tmp/test0.out && echo test0_passed`
- `./nic_sim.exe ../../test_students/test1_param.in ../../test_students/test1_packets.in > /tmp/test1.out && diff -u ../../test_students/test1_res.out /tmp/test1.out && echo test1_passed`
- `./nic_sim.exe ../../test_students/test2_param.in ../../test_students/test2_packets.in > /tmp/test2.out && diff -u ../../test_students/test2_res.out /tmp/test2.out && echo test2_passed`


------
https://chatgpt.com/codex/tasks/task_e_68a0bdc18924832eaea7ed74873a15ec