### PR TITLE
Harden packet validation and uppercase hex output

### DIFF
--- a/nic-sim-hw6/nic-sim-hw6/L2.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L2.cpp
@@ -67,7 +67,7 @@ void l2_packet::mac_to_string_upper(const uint8_t mac[MAC_SIZE], std::string& ou
     out.clear();
     for (int i=0;i<MAC_SIZE;i++) {
         char buf[3];
-        std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned int>(mac[i]));
+        std::snprintf(buf, sizeof(buf), "%02X", static_cast<unsigned int>(mac[i]));
         out += buf;
         if (i+1 != MAC_SIZE) out += ":";
     }
@@ -89,8 +89,11 @@ bool l2_packet::validate_packet(open_port_vec open_ports,
     }
     uint32_t l3_sum = inner_->raw_fields_checksum();
     sum += l3_sum;
-    sum += static_cast<uint8_t>((l3_sum >> 8) & 0xFF);
-    sum += static_cast<uint8_t>(l3_sum & 0xFF);
+    uint32_t l3_cs = inner_->get_checksum();
+    sum += static_cast<uint8_t>((l3_cs >> 24) & 0xFF);
+    sum += static_cast<uint8_t>((l3_cs >> 16) & 0xFF);
+    sum += static_cast<uint8_t>((l3_cs >> 8) & 0xFF);
+    sum += static_cast<uint8_t>(l3_cs & 0xFF);
     return sum == checksum_;
 }
 

--- a/nic-sim-hw6/nic-sim-hw6/L3.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L3.cpp
@@ -109,6 +109,10 @@ uint32_t l3_packet::raw_fields_checksum() const {
     return compute_checksum(src_ip_, dst_ip_, ttl_, dst_port_, src_port_, l4_index_, data_);
 }
 
+uint32_t l3_packet::get_checksum() const {
+    return checksum_;
+}
+
 void l3_packet::ip_to_string_upper(const uint8_t ip[4], std::string& out) {
     out.clear();
     out += std::to_string(ip[0]); out += ".";
@@ -151,7 +155,7 @@ bool l3_packet::proccess_packet(open_port_vec &open_ports,
     out_ttl_ = new_ttl;
 
     if (dst_is_nic) {
-        l4_packet inner(l4_index_, dst_port_, src_port_, data_);
+        l4_packet inner(l4_index_, src_port_, dst_port_, data_);
         memory_dest inner_dst;
         if (!(inner.validate_packet(open_ports, nic_ip, mask, nullptr) &&
               inner.proccess_packet(open_ports, nic_ip, mask, inner_dst))) {
@@ -202,7 +206,7 @@ bool l3_packet::as_string(std::string &packet) {
     packet += std::to_string(dst_port_) + "|" + std::to_string(src_port_) + "|" + std::to_string(l4_index_) + "|";
     for (size_t i = 0; i < data_.size(); ++i) {
         char buf[3];
-        std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned int>(data_[i]));
+        std::snprintf(buf, sizeof(buf), "%02X", static_cast<unsigned int>(data_[i]));
         packet += buf;
         if (i + 1 != data_.size()) packet += " ";
     }

--- a/nic-sim-hw6/nic-sim-hw6/L3.h
+++ b/nic-sim-hw6/nic-sim-hw6/L3.h
@@ -34,6 +34,7 @@ public:
                                      const std::vector<uint8_t>& data);
 
     uint32_t raw_fields_checksum() const;
+    uint32_t get_checksum() const;
 
 private:
     static bool parse_ip(const std::string& s, uint8_t out[common::IP_V4_SIZE]);

--- a/nic-sim-hw6/nic-sim-hw6/L4.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L4.cpp
@@ -81,7 +81,7 @@ bool l4_packet::as_string(std::string &packet) {
     packet += std::to_string(index_) + "|";
     for (size_t i = 0; i < data_.size(); ++i) {
         char buf[3];
-        std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned int>(data_[i]));
+        std::snprintf(buf, sizeof(buf), "%02X", static_cast<unsigned int>(data_[i]));
         packet += buf;
         if (i + 1 != data_.size()) packet += " ";
     }

--- a/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
@@ -6,6 +6,8 @@
 #include <cstring>
 #include <cstdlib>
 #include <memory>
+#include <algorithm>
+#include <cctype>
 
 using namespace common;
 
@@ -113,13 +115,17 @@ nic_sim::nic_sim(std::string param_file) {
     }
 }
 
+
 void nic_sim::nic_flow(std::string packet_file) {
     auto* priv = get_priv(this);
     std::ifstream in(packet_file);
     std::string line;
     while (std::getline(in, line)) {
-        if (line.empty()) continue;
-        auto pkt = packet_factory(line);
+        auto trimmed = line;
+        trimmed.erase(trimmed.begin(), std::find_if(trimmed.begin(), trimmed.end(), [](int ch){ return !std::isspace(ch); }));
+        trimmed.erase(std::find_if(trimmed.rbegin(), trimmed.rend(), [](int ch){ return !std::isspace(ch); }).base(), trimmed.end());
+        if (trimmed.empty()) continue;
+        auto pkt = packet_factory(trimmed);
         if (!pkt) continue;
 
         if (!pkt->validate_packet(open_ports, priv->ip, priv->mask_bits, priv->mac)) {
@@ -143,7 +149,7 @@ void nic_sim::nic_print_results() {
         std::cout << op.src_prt << " " << op.dst_prt << ": ";
         for (int i = 0; i < DATA_ARR_SIZE; i++) {
             char buf[3];
-            std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned int>(op.data[i]));
+            std::snprintf(buf, sizeof(buf), "%02X", static_cast<unsigned int>(op.data[i]));
             std::cout << buf;
             if (i + 1 != DATA_ARR_SIZE) std::cout << " ";
         }
@@ -169,8 +175,6 @@ nic_sim::~nic_sim() {
         }
     }
 }
-
-#include <cctype>
 
 static bool looks_like_mac_packet(const std::string& s) {
     int colons = 0;

--- a/nic-sim-hw6/nic-sim-hw6/common.hpp
+++ b/nic-sim-hw6/nic-sim-hw6/common.hpp
@@ -60,7 +60,7 @@ namespace common {
 
         /**
          * @fn print_hex_byte
-         * @brief Prints a single byte as a 2-digit lowercase hexadecimal number.
+         * @brief Prints a single byte as a 2-digit uppercase hexadecimal number.
          *
          * @param idx - Index of the char in 'data' to print.
          *
@@ -71,8 +71,8 @@ namespace common {
          *      output.
          */
         void print_hex_byte(int idx) {
-            std::cout << std::hex << std::setw(2) << std::setfill('0')
-                    << static_cast<int>(data[idx]) << std::dec;
+            std::cout << std::uppercase << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<int>(data[idx]) << std::nouppercase << std::dec;
         }
     };
 


### PR DESCRIPTION
## Summary
- Print all packet hex data in uppercase for spec compliance
- Correct L4 packet construction for NIC-bound traffic
- Rework L2 checksum calculation to include inner L3 checksum and ignore whitespace-only packet lines

## Testing
- `cd nic-sim-hw6/nic-sim-hw6 && make clean >/tmp/make.log && make >>/tmp/make.log && tail -n 20 /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9dd53b8832e8c393d97947971a7