### PR TITLE
Fix port and checksum handling in NIC simulator

### DIFF
--- a/nic-sim-hw6/nic-sim-hw6/L2.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L2.cpp
@@ -43,24 +43,25 @@ l2_packet::l2_packet(const std::string& s) {
 
 bool l2_packet::parse_mac(const std::string& s, uint8_t out[MAC_SIZE]) {
     size_t a = 0;
-    for (int i=0;i<MAC_SIZE;i++) {
+    for (int i = 0; i < MAC_SIZE; i++) {
         if (a + 1 >= s.size()) return false;
-        auto hexval = [](char c)->int{
-            if ('0'<=c && c<='9') return c - '0';
-            if ('a'<=c && c<='f') return 10 + (c - 'a');
-            if ('A'<=c && c<='F') return 10 + (c - 'A');
+        auto hexval = [](char c) -> int {
+            if ('0' <= c && c <= '9') return c - '0';
+            if ('a' <= c && c <= 'f') return 10 + (c - 'a');
+            if ('A' <= c && c <= 'F') return 10 + (c - 'A');
             return -1;
         };
         int v1 = hexval(s[a]);
-        int v2 = hexval(s[a+1]);
-        if (v1<0 || v2<0) return false;
-        out[i] = static_cast<uint8_t>((v1<<4)|v2);
-        if (i<MAC_SIZE-1) {
-            if (a+2 >= s.size() || s[a+2] != ':') return false;
-            a += 3;
+        int v2 = hexval(s[a + 1]);
+        if (v1 < 0 || v2 < 0) return false;
+        out[i] = static_cast<uint8_t>((v1 << 4) | v2);
+        a += 2;
+        if (i < MAC_SIZE - 1) {
+            if (a >= s.size() || s[a] != ':') return false;
+            ++a;
         }
     }
-    return true;
+    return a == s.size();
 }
 
 void l2_packet::mac_to_string_upper(const uint8_t mac[MAC_SIZE], std::string& out) {
@@ -71,6 +72,86 @@ void l2_packet::mac_to_string_upper(const uint8_t mac[MAC_SIZE], std::string& ou
         out += buf;
         if (i+1 != MAC_SIZE) out += ":";
     }
+}
+
+static bool parse_ip_token(const std::string& s, uint8_t out[IP_V4_SIZE]) {
+    size_t a = 0, b;
+    for (int i = 0; i < IP_V4_SIZE; i++) {
+        b = s.find(i < 3 ? '.' : '\0', a);
+        std::string part = (i < 3) ? s.substr(a, b - a) : s.substr(a);
+        if (part.empty()) return false;
+        int val = std::stoi(part);
+        if (val < 0 || val > 255) return false;
+        out[i] = static_cast<uint8_t>(val);
+        if (i < 3) a = b + 1;
+    }
+    return true;
+}
+
+static bool l3_sum_from_string(const std::string& s, uint32_t &sum) {
+    size_t p[7];
+    size_t last = 0;
+    for (int i = 0; i < 7; i++) {
+        p[i] = s.find('|', last);
+        if (p[i] == std::string::npos) return false;
+        last = p[i] + 1;
+    }
+    std::string src_s = s.substr(0, p[0]);
+    std::string dst_s = s.substr(p[0] + 1, p[1] - p[0] - 1);
+    std::string ttl_s = s.substr(p[1] + 1, p[2] - p[1] - 1);
+    std::string dstp_s = s.substr(p[3] + 1, p[4] - p[3] - 1);
+    std::string srcp_s = s.substr(p[4] + 1, p[5] - p[4] - 1);
+    std::string idx_s = s.substr(p[5] + 1, p[6] - p[5] - 1);
+    std::string data_s = s.substr(p[6] + 1);
+
+    uint8_t src_ip[IP_V4_SIZE], dst_ip[IP_V4_SIZE];
+    if (!parse_ip_token(src_s, src_ip) || !parse_ip_token(dst_s, dst_ip)) return false;
+    sum = 0;
+    for (int i = 0; i < IP_V4_SIZE; i++) {
+        sum += src_ip[i];
+        sum += dst_ip[i];
+    }
+    try {
+        uint32_t ttl = static_cast<uint32_t>(std::stoul(ttl_s));
+        sum += static_cast<uint8_t>(ttl & 0xFF);
+        uint16_t dst_port = static_cast<uint16_t>(std::stoul(dstp_s));
+        sum += static_cast<uint8_t>((dst_port >> 8) & 0xFF);
+        sum += static_cast<uint8_t>(dst_port & 0xFF);
+        uint16_t src_port = static_cast<uint16_t>(std::stoul(srcp_s));
+        sum += static_cast<uint8_t>((src_port >> 8) & 0xFF);
+        sum += static_cast<uint8_t>(src_port & 0xFF);
+        uint32_t idx = static_cast<uint32_t>(std::stoul(idx_s));
+        sum += static_cast<uint8_t>((idx >> 24) & 0xFF);
+        sum += static_cast<uint8_t>((idx >> 16) & 0xFF);
+        sum += static_cast<uint8_t>((idx >> 8) & 0xFF);
+        sum += static_cast<uint8_t>(idx & 0xFF);
+    } catch (...) {
+        return false;
+    }
+
+    std::vector<uint8_t> bytes;
+    auto hexval = [](char c) -> int {
+        if ('0' <= c && c <= '9') return c - '0';
+        if ('a' <= c && c <= 'f') return 10 + (c - 'a');
+        if ('A' <= c && c <= 'F') return 10 + (c - 'A');
+        return -1;
+    };
+    size_t i = 0;
+    while (i < data_s.size()) {
+        while (i < data_s.size() && std::isspace(static_cast<unsigned char>(data_s[i]))) ++i;
+        if (i >= data_s.size()) break;
+        if (i + 1 >= data_s.size()) return false;
+        int v1 = hexval(data_s[i]);
+        int v2 = hexval(data_s[i + 1]);
+        if (v1 < 0 || v2 < 0) return false;
+        bytes.push_back(static_cast<uint8_t>((v1 << 4) | v2));
+        i += 2;
+        while (i < data_s.size() && std::isspace(static_cast<unsigned char>(data_s[i]))) ++i;
+        if (i < data_s.size() && data_s[i] == ' ') ++i;
+    }
+    if (bytes.size() != PACKET_DATA_SIZE) return false;
+    for (auto b : bytes) sum += b;
+    return true;
 }
 
 bool l2_packet::validate_packet(open_port_vec open_ports,
@@ -87,10 +168,9 @@ bool l2_packet::validate_packet(open_port_vec open_ports,
         sum += src_mac_[i];
         sum += dst_mac_[i];
     }
-    uint32_t l3_sum = inner_->raw_fields_checksum();
+    uint32_t l3_sum;
+    if (!l3_sum_from_string(l3_string_, l3_sum)) return false;
     sum += l3_sum;
-    sum += static_cast<uint8_t>((l3_sum >> 8) & 0xFF);
-    sum += static_cast<uint8_t>(l3_sum & 0xFF);
     return sum == checksum_;
 }
 
@@ -116,13 +196,8 @@ bool l2_packet::proccess_packet(open_port_vec &open_ports,
 bool l2_packet::as_string(std::string &packet) {
     if (to_rq_ || to_tq_) {
         packet = out_l3_string_;
-        return true;
+    } else {
+        packet.clear();
     }
-    std::string s_mac, d_mac;
-    mac_to_string_upper(src_mac_, s_mac);
-    mac_to_string_upper(dst_mac_, d_mac);
-    packet.clear();
-    packet += s_mac + "|" + d_mac + "|" + out_l3_string_ + "|";
-    packet += std::to_string(0);
     return true;
 }

--- a/nic-sim-hw6/nic-sim-hw6/L3.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/L3.cpp
@@ -151,7 +151,7 @@ bool l3_packet::proccess_packet(open_port_vec &open_ports,
     out_ttl_ = new_ttl;
 
     if (dst_is_nic) {
-        l4_packet inner(l4_index_, dst_port_, src_port_, data_);
+        l4_packet inner(l4_index_, src_port_, dst_port_, data_);
         memory_dest inner_dst;
         if (!(inner.validate_packet(open_ports, nic_ip, mask, nullptr) &&
               inner.proccess_packet(open_ports, nic_ip, mask, inner_dst))) {

--- a/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
+++ b/nic-sim-hw6/nic-sim-hw6/NIC_sim.cpp
@@ -27,24 +27,25 @@ static std::string trim(const std::string &s) {
 
 static bool parse_mac_line(const std::string& s, uint8_t mac[MAC_SIZE]) {
     size_t a = 0;
-    for (int i=0;i<MAC_SIZE;i++) {
+    for (int i = 0; i < MAC_SIZE; i++) {
         if (a + 1 >= s.size()) return false;
-        auto hexval = [](char c)->int{
-            if ('0'<=c && c<='9') return c - '0';
-            if ('a'<=c && c<='f') return 10 + (c - 'a');
-            if ('A'<=c && c<='F') return 10 + (c - 'A');
+        auto hexval = [](char c) -> int {
+            if ('0' <= c && c <= '9') return c - '0';
+            if ('a' <= c && c <= 'f') return 10 + (c - 'a');
+            if ('A' <= c && c <= 'F') return 10 + (c - 'A');
             return -1;
         };
         int v1 = hexval(s[a]);
-        int v2 = hexval(s[a+1]);
-        if (v1<0 || v2<0) return false;
-        mac[i] = static_cast<uint8_t>((v1<<4)|v2);
-        if (i<MAC_SIZE-1) {
-            if (a+2 >= s.size() || s[a+2] != ':') return false;
-            a += 3;
+        int v2 = hexval(s[a + 1]);
+        if (v1 < 0 || v2 < 0) return false;
+        mac[i] = static_cast<uint8_t>((v1 << 4) | v2);
+        a += 2;
+        if (i < MAC_SIZE - 1) {
+            if (a >= s.size() || s[a] != ':') return false;
+            ++a;
         }
     }
-    return true;
+    return a == s.size();
 }
 
 static bool parse_ip_mask_line(const std::string& s, uint8_t ip[IP_V4_SIZE], uint8_t &mask_bits) {
@@ -137,7 +138,7 @@ nic_sim::nic_sim(std::string param_file) {
         if (line.empty() || line[0] == '#') continue;
         uint16_t src, dst;
         if (parse_open_port_line(line, src, dst)) {
-            open_ports.emplace_back(dst, src);
+            open_ports.emplace_back(src, dst);
         }
     }
 }
@@ -168,6 +169,14 @@ void nic_sim::nic_flow(std::string packet_file) {
 }
 
 void nic_sim::nic_print_results() {
+    std::cout << "RQ:\n";
+    for (const auto& s : RQ) {
+        std::cout << s << "\n";
+    }
+    std::cout << "TQ:\n";
+    for (const auto& s : TQ) {
+        std::cout << s << "\n";
+    }
     std::cout << "LOCAL DRAM:\n";
     for (const auto& op : open_ports) {
         std::cout << op.src_prt << " " << op.dst_prt << ": ";
@@ -178,14 +187,6 @@ void nic_sim::nic_print_results() {
             if (i + 1 != DATA_ARR_SIZE) std::cout << " ";
         }
         std::cout << "\n";
-    }
-    std::cout << "\nRQ:\n";
-    for (const auto& s : RQ) {
-        std::cout << s << "\n";
-    }
-    std::cout << "\nTQ:\n";
-    for (const auto& s : TQ) {
-        std::cout << s << "\n";
     }
 }
 
@@ -209,13 +210,16 @@ static bool looks_like_mac_packet(const std::string& s) {
 static bool looks_like_l3_packet(const std::string& s) {
     size_t p1 = s.find('|');
     if (p1 == std::string::npos) return false;
-    auto is_ip = [](const std::string& t)->bool{
+    auto is_ip = [](const std::string& t) -> bool {
         int dots = 0;
-        for (char c: t) if (c=='.') dots++;
-        return dots==3;
+        for (char c : t) if (c == '.') dots++;
+        return dots == 3;
     };
     std::string first = s.substr(0, p1);
-    return is_ip(first);
+    if (!is_ip(first)) return false;
+    int bars = 0;
+    for (char c : s) if (c == '|') ++bars;
+    return bars >= 7;
 }
 
 std::unique_ptr<generic_packet> nic_sim::packet_factory(std::string &packet) {


### PR DESCRIPTION
## Summary
- store open ports using src/dst order and print results as RQ/TQ/LOCAL DRAM
- validate L3/L4 packet wiring with correct port order and stricter heuristics
- tighten MAC parsing and recompute L2 checksums byte-wise

## Testing
- `make`
- `./nic_sim.exe ../../test_students/test0_param.in ../../test_students/test0_packets.in`
- `./nic_sim.exe ../../test_students/test1_param.in ../../test_students/test1_packets.in`
- `./nic_sim.exe ../../test_students/test2_param.in ../../test_students/test2_packets.in`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8e8781c832ea032ca184aabbab2